### PR TITLE
fix: title array is empty

### DIFF
--- a/lib/notion.ts
+++ b/lib/notion.ts
@@ -26,7 +26,7 @@ async function generateNotionPostMetadata(
 		date: page.created_time,
 		updated: page.last_edited_time,
 		title:
-			page.properties.Name.type === "title"
+			page.properties.Name.type === "title" && page.properties.Name.title.length > 0
 				? page.properties.Name.title[0].plain_text
 				: "",
 		description: "",


### PR DESCRIPTION
Notion allows a page to stay untitled which makes the title array empty.
<img width="161" alt="image" src="https://github.com/kanoshiou/burogu-1/assets/73424326/679cf564-0ddd-4b39-999e-83c2da80acd3">
